### PR TITLE
Refactor Board class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Conway's Game of Life
 
 ### Overview
-
 Console implementation of Conway's Game of Life created using C++.
 
+---
 ### Build and Run Instructions (Unix/Linux)
 1. Verify that [cmake](https://cmake.org/) is installed. (Needs to be at least version 3.21)
 2. Create a build directory within project directory
@@ -11,7 +11,20 @@ Console implementation of Conway's Game of Life created using C++.
 4. To build project run: `make` from the build directory
 5. To start the program run: `./game_of_life` from the build directory
 
-### Starting Screen
+---
+### Game of Life Rule Set
+1. Births: Each dead cell adjacent to exactly three live neighbors will become
+   live in the next generation.
+2. Death by isolation: Each live cell with one or fewer live neighbors will die
+   in the next generation.
+3. Death by overcrowding: Each live cell with four or more live neighbors will
+   die in the next generation.
+4. Survival: Each live cell with either two or three live neighbors will remain
+   alive for the next generation.
+5. Apply rules to all cells at the same time.
+
+---
+### Example Screen
 ```
    | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10| 11| 12| 13| 14| 15| 16| 17| 18| 19|
    ---------------------------------------------------------------------------------

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -72,7 +72,7 @@ void Board::printBoard() {
 }
 
 void Board::printHorizontalLine() const {
-    cout  <<"   "; // offest space accounts for numbering of each row.
+    cout  <<"   "; // offset space accounts for numbering of each row.
 	for(int q {0}; q < ((col * 4) + 1); q++) {
 		cout <<'-';
 	}
@@ -105,8 +105,8 @@ void Board::setupBoard() {
 }
 
 // Able to load special configuration files where each line in external file is a 2-pair tuple
-// indicating row and column position separated by a comma and each tuple sepated by a newline.
-bool Board::loadConfig(std::string fileName) {
+// indicating row and column position separated by a comma and each tuple separated by a newline.
+bool Board::loadConfig(const std::string& fileName) {
     std::ifstream fin;
     fin.open(fileName);
     if(!fin) {
@@ -130,7 +130,7 @@ bool Board::loadConfig(std::string fileName) {
     }
 }
 
-bool Board::saveBoard(std::string fileName) {
+bool Board::saveBoard(const std::string& fileName) {
     std::ofstream fout;
     fout.open(fileName);
     if(!fout) {
@@ -149,7 +149,7 @@ bool Board::saveBoard(std::string fileName) {
     }
 }
 
-bool Board::loadBoard(std::string fileName) {
+bool Board::loadBoard(const std::string& fileName) {
     std::ifstream fin;
     fin.open(fileName);
     if(!fin) {
@@ -299,11 +299,11 @@ bool Board::isZero() {
 }
 
 // TODO: use this for stopping auto generate when board doesn't change on update
-bool Board::operator==(Cell ** other_board) {
+bool Board::operator==(Cell ** other_board) const {
     for (int i = 0; i < row; i++) {
         for (int j = 0; j < col; j++) {
             // TODO: overload != operator for Cell class
-            //if (board[i][j] != other_board[i][j]) { return false; }
+            // if (board[i][j] != other_board[i][j]) { return false; }
         };
     }
     return false;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -121,7 +121,6 @@ bool Board::loadConfig(const std::string& fileName) {
             fin.ignore(100,',');
             fin >> y;
             fin.ignore(100,'\n');
-            cout <<"X: " <<x <<" Y: " <<y <<endl;
             setState(x, y, true);
         }
         fin.close();
@@ -297,13 +296,13 @@ bool Board::isZero() {
     return true;
 }
 
-// TODO: use this for stopping auto generate when board doesn't change on update
 bool Board::operator==(Cell ** other_board) const {
     for (int i = 0; i < row; i++) {
         for (int j = 0; j < col; j++) {
-            // TODO: overload != operator for Cell class
-            // if (board[i][j] != other_board[i][j]) { return false; }
+            if (board[i][j].isAlive() != other_board[i][j].isAlive()) {
+                return false;
+            }
         };
     }
-    return false;
+    return true;
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -39,6 +39,9 @@ Board::Board(const Board & src) {
     board = new Cell * [row];
     for(int i = 0; i < row; i++) {
         board[i] = new Cell[col];
+        for(int j = 0; j < col; ++j) {
+            board[i][j].setLife(src.board[i][j].isAlive());
+        }
     }
 }
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -288,7 +288,6 @@ void Board::autoNextGen() {
 }
 
 bool Board::isZero() {
-    int result = 0;
     for(int i = 0; i < ROW; i++) {
         for(int j = 0; j < COL; j++) {
            if(board[i][j].isAlive())

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -4,24 +4,6 @@
 #include "Cell.h"
 #include "Application.h"
 
-/*
-                        Game of Life rule set
-
-1. Births: Each dead cell adjacent to exactly three live neighbors will become
-   live in the next generation.
-
-2. Death by isolation: Each live cell with one or fewer live neighbors will die
-   in the next generation.
-
-3. Death by overcrowding: Each live cell with four or more live neighbors will
-   die in the next generation.
-
-4. Survival: Each live cell with either two or three live neighbors will remain
-   alive for the next generation.
-
-Apply rules to all cells at the same time.
-*/
-
 using std::cout;
 using std::endl;
 using std::cin;
@@ -60,7 +42,6 @@ void Board::setState(int r, int c, bool x) {
 	board[r][c].setLife(x);
 }
 
-// Doesn't really work that well. Have trouble representing the grid with spacing issues.
 void Board::printColNum() const {
     cout <<"   |";
     for(int j {0}; j < col; ++j) {
@@ -123,10 +104,10 @@ void Board::setupBoard() {
     updateNeighbors();
 }
 
-// Able to load special configuration files where each line in external file is a 2-pair tuple indicating row and column
-// position separated by a comma and each tuple sepated by a newline (e.g. 2,4
-bool Board::loadConfig(std::string fileName) {   //                        3,6
-    std::ifstream fin;                           //                        7,8)
+// Able to load special configuration files where each line in external file is a 2-pair tuple
+// indicating row and column position separated by a comma and each tuple sepated by a newline.
+bool Board::loadConfig(std::string fileName) {
+    std::ifstream fin;
     fin.open(fileName);
     if(!fin) {
         std::cerr <<"File could not be opened" <<endl;
@@ -191,7 +172,6 @@ bool Board::loadBoard(std::string fileName) {
     }
 }
 
-// Prompts user to draw on board and then save the board to external file.
 void Board::draw() {
     char response;
     do {
@@ -221,12 +201,6 @@ void Board::reset() {
     }
 }
 
-/* Rules for surviving the next generation;
- * 1. Any live cell with two or three live neighbours survives.
- * 2. Any dead cell with three live neighbours becomes a live cell.
- * 3. All other live cells die in the next generation. Similarly, all other dead cells stay dead.
- */
-// Wrapper function for getting the next generation of cell states
 void Board::nextGen() {
     // board containing next generation
     Cell ** hold = getNextGen();

--- a/src/Board.h
+++ b/src/Board.h
@@ -17,8 +17,8 @@ public:
     void reset();
     void nextGen();
     void autoNextGen();
-    void setupBoard(); // prompts user to set up the game.
-    void draw(); // saves board states
+    void setupBoard();
+    void draw();
     void printBoard();
     bool loadBoard(std::string fileName);
     bool loadConfig(std::string fileName);

--- a/src/Board.h
+++ b/src/Board.h
@@ -5,7 +5,6 @@
 #include <fstream>
 #include "Cell.h"
 
-// Default size of game board
 #define ROW 10
 #define COL 20
 

--- a/src/Board.h
+++ b/src/Board.h
@@ -20,11 +20,11 @@ public:
     void setupBoard();
     void draw();
     void printBoard();
-    bool loadBoard(std::string fileName);
-    bool loadConfig(std::string fileName);
-    bool saveBoard(std::string fileName);
+    bool loadBoard(const std::string& fileName);
+    bool loadConfig(const std::string& fileName);
+    bool saveBoard(const std::string& fileName);
     bool isZero();
-    bool operator==(Cell **);
+    bool operator==(Cell **) const;
 
 private:
     Cell ** board;


### PR DESCRIPTION
Fixed copy constructor and '==' operator logic for board class. Also cleaned up a lot of unnecessary comments. The game of life ruleset was in a comment within the class implementation file, so I moved it to the README instead for better documentation. 